### PR TITLE
Add v6 "What's New" mini-tour for returning users

### DIFF
--- a/src/data/constants.js
+++ b/src/data/constants.js
@@ -1280,10 +1280,26 @@ export const TOUR_STEPS = [
   { title: "Human-Curated Pipeline", description: "This is what makes Atlas different. Every insight passes through your curation — the AI proposes, you decide. Your knowledge base is human-verified, not just AI-generated.", icon: "⚖️", highlight: true },
   { title: "Quick Navigation", description: "Press ⌘K (or Ctrl+K) anytime to open the command palette. Jump to any topic or view instantly.", icon: "⌕", target: "[data-tour='cmd-k']" },
   { title: "Incremental Sync", description: "Atlas isn't a one-time tool. Hit Sync to pull in new conversations and keep your knowledge base current.", icon: "⟳", target: "[data-tour='sync']" },
+  { title: "Ask Atlas", description: "Your knowledge has a voice now. Open the Companion tab to ask Atlas anything about your conversations — it queries across all your curated insights.", icon: "◆", target: "[data-tour='companion-tab']" },
+  { title: "Belief Diffs", description: "See how your thinking evolved. Belief Diffs show side-by-side comparisons of your past and present positions on any topic.", icon: "⇄", target: "[data-tour='belief-diffs-tab']" },
+  { title: "Monthly Digest", description: "Your knowledge, summarized. The Digest generates a monthly recap of conversations, new connections, and thinking shifts — like Spotify Wrapped for your mind.", icon: "📅", target: "[data-tour='digest-tab']" },
+  { title: "Rewind Mode", description: "Watch your knowledge graph grow over time. Rewind replays how topics and connections formed across months of conversations.", icon: "⏪", target: "[data-tour='rewind-btn']" },
   { title: "You're All Set!", description: "Explore your 3 years of AI conversations, mapped and curated. Your mind, your atlas.", icon: "✨" },
 ];
 
 export const TOUR_STORAGE_KEY = "atlas_tour_completed";
+
+// ─── V6 "WHAT'S NEW" MINI-TOUR (for returning users) ────
+export const V6_TOUR_STEPS = [
+  { title: "What's New in v6", description: "Welcome back! Atlas v6 turns your curated knowledge into an active companion. Here's what's new.", icon: "🆕", highlight: true },
+  { title: "Ask Atlas", description: "Query your entire knowledge base in natural language. Atlas answers using only your curated, human-verified insights.", icon: "◆", target: "[data-tour='companion-tab']" },
+  { title: "Belief Diffs", description: "Compare how your thinking on any topic has shifted over time with side-by-side diffs.", icon: "⇄", target: "[data-tour='belief-diffs-tab']" },
+  { title: "Monthly Digest", description: "Auto-generated monthly summaries of your conversations, new connections, and thinking shifts.", icon: "📅", target: "[data-tour='digest-tab']" },
+  { title: "Companion Sidebar", description: "A persistent sidebar that offers contextual suggestions as you navigate. Open it anytime with ⌘/ (Ctrl+/).", icon: "💡", target: "[data-tour='companion-sidebar']" },
+  { title: "You're Caught Up!", description: "That's everything new in v6. Your knowledge now compounds — Atlas remembers so you don't have to.", icon: "✨" },
+];
+
+export const V6_TOUR_STORAGE_KEY = "atlas_v6_tour_completed";
 
 // ─── PAST ANALOGIES DATA (for "What Would Past-Me Say?") ──
 export const PAST_ANALOGIES = [

--- a/src/store.js
+++ b/src/store.js
@@ -15,6 +15,7 @@ const useStore = create((set, get) => ({
   cmdPaletteOpen: false,
   briefingTopic: null,
   tourActive: false,
+  v6TourActive: false,
 
   setView: (view) => set({ view }),
   setSelectedTopic: (topic) => set({ selectedTopic: topic }),
@@ -24,6 +25,7 @@ const useStore = create((set, get) => ({
   setCmdPaletteOpen: (open) => set({ cmdPaletteOpen: open }),
   setBriefingTopic: (topic) => set({ briefingTopic: topic }),
   setTourActive: (active) => set({ tourActive: active }),
+  setV6TourActive: (active) => set({ v6TourActive: active }),
 
   navigateTo: (viewId) => {
     if (viewId === 'rewind') set({ showRewind: true });


### PR DESCRIPTION
## Summary
Introduces a new guided tour experience for returning users upgrading to v6, while making the GuidedTour component reusable for multiple tour flows. This allows new users to see the full feature tour on first visit, while existing users get a focused "What's New in v6" mini-tour highlighting the latest features.

## Key Changes

- **Parameterized GuidedTour component**: Modified `GuidedTour` to accept `steps` and `storageKey` props, enabling reuse for different tour flows instead of being hardcoded to `TOUR_STEPS`
- **New V6 tour constants**: Added `V6_TOUR_STEPS` and `V6_TOUR_STORAGE_KEY` to `constants.js` with a focused 6-step tour covering Companion, Belief Diffs, Digest, and Companion Sidebar
- **Dual tour state management**: Added `v6TourActive` and `setV6TourActive` to store for independent control of the v6 mini-tour
- **Smart tour activation logic**: Updated app initialization to show full tour for new users (no `TOUR_STORAGE_KEY`), and v6 mini-tour for returning v5 users (no `V6_TOUR_STORAGE_KEY`)
- **Tour targeting attributes**: Added `data-tour` attributes to navigation tabs (companion, belief-diffs, digest), rewind button, and companion sidebar for tour step highlighting
- **Dual tour buttons**: Added separate "Tour" and "v6" buttons in the bottom-left corner, allowing users to manually trigger either tour experience
- **Enhanced full tour**: Extended the main tour with 4 new steps covering Companion, Belief Diffs, Digest, and Rewind Mode features

## Implementation Details

- The `GuidedTour` component now defaults to `TOUR_STEPS` and `TOUR_STORAGE_KEY` for backward compatibility
- Tour step targeting uses CSS selectors via `data-tour` attributes for flexible element selection
- Both tours are rendered simultaneously but only one is active at a time based on state
- Storage keys prevent tour re-display: returning users see v6 tour once, then never again

https://claude.ai/code/session_01Ac4w4fCQm4KS8VT9Qt3wA2